### PR TITLE
test: added page object with types example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Checks are written against React Admin demo and will include the following
 - [x] [Monkey testing with Gremlin.js](playwright-test/tests/monkey-testing.spec.ts)
 - [x] Fullscreen capture on test failure
 - [x] Override/extend test fixtures
+- [x] Page Object with custom type
 
 # Setup
 

--- a/playwright-test/pageObjects/invoices.page.ts
+++ b/playwright-test/pageObjects/invoices.page.ts
@@ -1,0 +1,30 @@
+import { Locator, Page } from "@playwright/test";
+
+type SortLabel = "id" | "customer" | "address" | "order";
+
+export enum SortType {
+  "id" = "id",
+  "customer" = "customer_id",
+  "address" = "customer_id",
+  "total ex taxes" = "total_ex_taxes",
+  "delivery fees" = "delivery_fees",
+}
+
+export class InvoicesPage {
+  readonly page: Page;
+  readonly invoiceTableHeader: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.invoiceTableHeader = page.locator("#main-content .MuiTable-root .MuiTableHead-root");
+  }
+
+  async goto() {
+    await this.page.goto("/react-admin-demo/#/invoices");
+  }
+
+  async sortBy(label: keyof typeof SortType) {
+    const header = await this.invoiceTableHeader.locator(`tr >> text=/${label}/i`);
+    await header.click();
+  }
+}

--- a/playwright-test/tests/invoices-using-po.spec.ts
+++ b/playwright-test/tests/invoices-using-po.spec.ts
@@ -1,0 +1,15 @@
+import test from "../fixtures/base-fixture";
+import { InvoicesPage, SortType } from "../pageObjects/invoices.page";
+
+test.use({ storageState: "state.json" });
+
+const { describe, expect } = test;
+
+describe("Invoices and Page Object", () => {
+  test("should be able to update table sorting", async ({ page }) => {
+    const invoicesPage = new InvoicesPage(page);
+    await invoicesPage.goto();
+    await invoicesPage.sortBy("total ex taxes");
+    expect(await page.url()).toContain(SortType["total ex taxes"]);
+  });
+});


### PR DESCRIPTION
# Why
Added example test with Page Object Model (POM) 

> 💡 While this is a more organised way to "describe" a page. It really depends on the usage, POM adds an additional layer of complexity that could be solve by structuring tests as well. E.g.: Tests could be split into small enough journey that there are no overlaps. 